### PR TITLE
configure load balancer health check

### DIFF
--- a/openchallenges/service_stack.py
+++ b/openchallenges/service_stack.py
@@ -158,12 +158,12 @@ class LoadBalancedServiceStack(ServiceStack):
             protocol=elbv2.ApplicationProtocol.HTTP,
         )
 
-        health_check = elbv2.HealthCheck(path="/", interval=duration.minutes(1))
+        health_check = elbv2.HealthCheck(
+            path="/", interval=duration.minutes(1), enabled=False
+        )
         if "apex" in construct_id:
-            health_check = elbv2.HealthCheck(
-                path="/api/v1/challenges?pageNumber=1&pageSize=1",
-                interval=duration.minutes(5),
-            )
+            health_check.path = "/health"
+            health_check.interval = duration.minutes(5)
 
         http_listener.add_targets(
             "Target",

--- a/openchallenges/service_stack.py
+++ b/openchallenges/service_stack.py
@@ -162,8 +162,9 @@ class LoadBalancedServiceStack(ServiceStack):
             path="/", interval=duration.minutes(1), enabled=False
         )
         if "apex" in construct_id:
-            health_check.path = "/health"
-            health_check.interval = duration.minutes(5)
+            health_check = elbv2.HealthCheck(
+                path="/health", interval=duration.minutes(5), enabled=False
+            )
 
         http_listener.add_targets(
             "Target",

--- a/openchallenges/service_stack.py
+++ b/openchallenges/service_stack.py
@@ -1,6 +1,7 @@
 import aws_cdk as cdk
 
 from aws_cdk import (
+    Duration as duration,
     aws_ecs as ecs,
     aws_ec2 as ec2,
     aws_logs as logs,
@@ -157,11 +158,19 @@ class LoadBalancedServiceStack(ServiceStack):
             protocol=elbv2.ApplicationProtocol.HTTP,
         )
 
+        health_check = elbv2.HealthCheck(path="/", interval=duration.minutes(1))
+        if "apex" in construct_id:
+            health_check = elbv2.HealthCheck(
+                path="/api/v1/challenges?pageNumber=1&pageSize=1",
+                interval=duration.minutes(5),
+            )
+
         http_listener.add_targets(
             "Target",
             port=props.container_port,
             protocol=elbv2.ApplicationProtocol.HTTP,
             targets=[self.service],
+            health_check=health_check,
         )
 
         # -------------------------------


### PR DESCRIPTION
AWS sets up a health check by default on load balancer creation.  Setup custom configurations for health checks but disable the health check for now to make it easier to debug deployment.
