### PR TITLE
health check must be enabled

### DIFF
--- a/openchallenges/service_stack.py
+++ b/openchallenges/service_stack.py
@@ -158,12 +158,10 @@ class LoadBalancedServiceStack(ServiceStack):
             protocol=elbv2.ApplicationProtocol.HTTP,
         )
 
-        health_check = elbv2.HealthCheck(
-            path="/", interval=duration.minutes(1), enabled=False
-        )
+        health_check = elbv2.HealthCheck(path="/", interval=duration.minutes(1))
         if "apex" in construct_id:
             health_check = elbv2.HealthCheck(
-                path="/health", interval=duration.minutes(5), enabled=False
+                path="/health", interval=duration.minutes(5)
             )
 
         http_listener.add_targets(


### PR DESCRIPTION
Deployment failed with this error..
```
UPDATE_FAILED| AWS::ElasticLoadBalancingV2::TargetGroup | HttpListenerTargetGroup541B85A7
Resource handler returned message: "Health check enabled must be true for target groups
with target type 'ip'
```

from AWS docs[1]:
```
if the target type is instance or ip, health checks are always enabled
and cannot be disabled
```

We setup ip target type because that's what is required when using fargate[2].
```
When you create any target groups, you must choose ip as the target type, not
instance
```

[1] https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_elasticloadbalancingv2/HealthCheck.html#aws_cdk.aws_elasticloadbalancingv2.HealthCheck
[2] https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-task-networking.html