### PR TITLE
Read environment and secret configs from cdk.json

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,21 +30,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Install dependencies
         run: pip install -r requirements.txt -r requirements-dev.txt
-      - name: Generate dummy secrets file
-        run: |
-          tee -a .openchallenges > /dev/null <<EOT
-          MARIADB_PASSWORD=dummy
-          MARIADB_ROOT_PASSWORD=dummy
-          GIT_HOST_KEY=DUMMY_GIT_HOST_KEY
-          GIT_PRIVATE_KEY=-----BEGIN OPENSSH PRIVATE KEY-----\nDUMMY_GIT_PRIVATE_KEY\n-----END OPENSSH PRIVATE KEY-----
-          AWS_LOADER_S3_ACCESS_KEY_ID=DUMMY_S3_ACCESS_KEY
-          AWS_LOADER_S3_SECRET_ACCESS_KEY=DUMMY_S3_SECRET_KEY
-          SECURITY_KEY=00000
-          EOT
       - name: Generate cloudformation
         uses: youyo/aws-cdk-github-actions@v2
         with:
           cdk_subcommand: 'synth'
           actions_comment: false
           debug_log: true
-          cdk_args: '--context env=dev --output ./cdk.out'
+          cdk_args: '--output ./cdk.out'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
       - id: yamllint
   - repo: https://github.com/awslabs/cfn-python-lint
-    rev: v1.2.5.a11
+    rev: v1.9.0
     hooks:
       - id: cfn-python-lint
         args:
@@ -35,15 +35,8 @@ repos:
     rev: 24.4.2
     hooks:
       - id: black
-  - repo: https://github.com/python-poetry/poetry
-    rev: '1.8.0'
-    hooks:
-      - id: poetry-check
-      - id: poetry-lock
-        language_version: python3.10
-        args: ['--check']
   - repo: https://github.com/sirosen/check-jsonschema
-    rev: 0.28.5
+    rev: 0.29.1
     hooks:
       - id: check-github-workflows
       - id: check-github-actions

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $ pip install -r requirements.txt -r requirements-dev.txt
 At this point you can now synthesize the CloudFormation template for this code.
 
 ```
-$ cdk --context env=dev synth
+$ cdk synth
 ```
 
 To add additional dependencies, for example other CDK libraries, just add
@@ -74,7 +74,7 @@ execute the validations by running `pre-commit run --all-files`.
 
 Verify CDK to Cloudformation conversion by running [cdk synth]:
 ```text
-cdk --context env=dev synth
+cdk synth
 ```
 The Cloudformation output is saved to the `cdk.out` folder
 
@@ -86,11 +86,109 @@ Tests are available in the tests folder. Execute the following to run tests:
 python -m pytest tests/ -s -v
 ```
 
+# Environments
+
+Deployment context is set in the [cdk.json](cdk.json) file.  An `ENV` environment variable must be set to
+tell the CDK which environment's variables to use when synthesising or deploying the stacks.
+
+Set an environment in cdk.json in `context` section of cdk.json:
+
+```text
+  "context": {
+    "dev": {
+        "VPC_CIDR": "10.255.92.0/24",
+        "DNS_NAMESPACE": "openchallenges-dev.io"
+      },
+    "prod": {
+        "VPC_CIDR": "10.255.93.0/24",
+        "DNS_NAMESPACE": "openchallenges.io"
+      },
+  }
+```
+
+Use `prod` environment:
+
+```commandline
+ENV=prod cdk synth
+```
+
+
+# Secrets
+
+Secrets can be stored in one of the following locations:
+  * AWS SSM parameter store
+  * Local context in [cdk.json](cdk.json) file
+
+## Loading directly from cdk.json:
+
+Set secrets directly in cdk.json in `context` section of cdk.json:
+
+```text
+  "context": {
+    "secrets": {
+        "MARIADB_PASSWORD": "Dummy",
+        "MARIADB_ROOT_PASSWORD": "Dummy",
+        "GIT_HOST_KEY": "Host123",
+        "GIT_PRIVATE_KEY": "-----BEGIN OPENSSH PRIVATE KEY-----\nDUMMY_GIT_PRIVATE_KEY\n-----END OPENSSH PRIVATE KEY-----",
+        "AWS_LOADER_S3_ACCESS_KEY_ID": "AccessKey123",
+        "AWS_LOADER_S3_SECRET_ACCESS_KEY": "SecretAccessKey123",
+        "SECURITY_KEY": "SecurityKey123"
+    }
+  }
+```
+
+## Loading from ssm parameter store:
+
+Set secrets to the SSM parameter names in `context` section of cdk.json:
+```text
+  "context": {
+    "secrets": {
+        "MARIADB_PASSWORD": "/openchallenges/MARIADB_PASSWORD",
+        "MARIADB_ROOT_PASSWORD": "/openchallenges/MARIADB_ROOT_PASSWORD",
+        "GIT_HOST_KEY": "/openchallenges/GIT_HOST_KEY",
+        "GIT_PRIVATE_KEY": "/openchallenges/GIT_PRIVATE_KEY",
+        "AWS_LOADER_S3_ACCESS_KEY_ID": "/openchallenges/AWS_LOADER_S3_ACCESS_KEY_ID",
+        "AWS_LOADER_S3_SECRET_ACCESS_KEY": "/openchallenges/AWS_LOADER_S3_SECRET_ACCESS_KEY",
+        "SECURITY_KEY": "/openchallenges/SECURITY_KEY"
+    }
+  }
+```
+
+__NOT__: The SSM parameter names contain the secret values
+
+## Specify secret location
+Set the `SECRETS` environment variable to specify the location where secrets should be loaded from.
+
+load secrets directly from cdk.json file:
+```commandline
+SECRETS=local cdk synth
+```
+
+load secrets from AWS SSM parameter store:
+```commandline
+SECRETS=ssm cdk synth
+```
+
+## Override secrets from command line
+
+The CDK CLI allows overriding context variables:
+
+To load secrets directly from passed in values:
+```commandline
+SECRETS=local cdk --context  secrets='{"MARIADB_PASSWORD": "Dummy", "MARIADB_ROOT_PASSWORD": "Dummy", ..}' synth
+```
+
+To load secrets from SSM parameter store with overridden SSM parameter names:
+```commandline
+SECRETS=ssm cdk --context  "secrets"='{"MARIADB_PASSWORD": "/test/mariadb-root-pass", "MARIADB_ROOT_PASSWORD": "/test/mariadb-root-pass", ..}' synth
+```
+
+
 # Deployment
 
 Deployment requires setting up an [AWS profile](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-quickstart.html) then executing the
 following command:
 
 ```text
-AWS_PROFILE=<your AWS profile> AWS_DEFAULT_REGION=<your region> cdk deploy --all
+AWS_PROFILE=<your AWS profile> AWS_DEFAULT_REGION=<your region> ENV=dev SECRETS=ssm cdk deploy --all
 ```

--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ load secrets from AWS SSM parameter store:
 SECRETS=ssm cdk synth
 ```
 
+__NOTE__: setting `SECRETS=ssm` requires access to an AWS account
+
 ## Override secrets from command line
 
 The CDK CLI allows overriding context variables:

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ automatically run on every commit.  Alternatively you can manually
 execute the validations by running `pre-commit run --all-files`.
 
 Verify CDK to Cloudformation conversion by running [cdk synth]:
-```text
+```commandline
 cdk synth
 ```
 The Cloudformation output is saved to the `cdk.out` folder
@@ -191,6 +191,6 @@ SECRETS=ssm cdk --context  "secrets"='{"MARIADB_PASSWORD": "/test/mariadb-root-p
 Deployment requires setting up an [AWS profile](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-quickstart.html) then executing the
 following command:
 
-```text
+```commandline
 AWS_PROFILE=<your AWS profile> AWS_DEFAULT_REGION=<your region> ENV=dev SECRETS=ssm cdk deploy --all
 ```

--- a/cdk.json
+++ b/cdk.json
@@ -66,6 +66,15 @@
     "dev": {
         "VPC_CIDR": "10.255.92.0/24",
         "DNS_NAMESPACE": "openchallenges.io"
-      }
+      },
+    "secrets": {
+        "MARIADB_PASSWORD": "/openchallenges/MARIADB_PASSWORD",
+        "MARIADB_ROOT_PASSWORD": "/openchallenges/MARIADB_ROOT_PASSWORD",
+        "GIT_HOST_KEY": "/openchallenges/GIT_HOST_KEY",
+        "GIT_PRIVATE_KEY": "/openchallenges/GIT_PRIVATE_KEY",
+        "AWS_LOADER_S3_ACCESS_KEY_ID": "/openchallenges/AWS_LOADER_S3_ACCESS_KEY_ID",
+        "AWS_LOADER_S3_SECRET_ACCESS_KEY": "/openchallenges/AWS_LOADER_S3_SECRET_ACCESS_KEY",
+        "SECURITY_KEY": "/openchallenges/SECURITY_KEY"
+    }
   }
 }

--- a/openchallenges/utils.py
+++ b/openchallenges/utils.py
@@ -1,0 +1,82 @@
+import boto3
+import aws_cdk as cdk
+
+from botocore.exceptions import ClientError
+from os import environ
+
+
+def get_environment() -> str:
+    """
+    The `env` environment variable's value represents the deployment
+    environment (dev, prod, etc..).  This method gets the `env`
+    environment variable's value
+    """
+    VALID_ENVS = ["dev", "prod"]
+
+    env_environment_var = environ.get("ENV")
+    if env_environment_var is None:
+        environment = "dev"  # default environment
+    elif env_environment_var in VALID_ENVS:
+        environment = env_environment_var
+    else:
+        valid_envs_str = ",".join(VALID_ENVS)
+        raise SystemExit(
+            f"Must set environment variable `ENV` to one of {valid_envs_str}"
+        )
+
+    return environment
+
+
+def get_secrets_location() -> dict:
+    """
+    The application's secrets can be saved in two places, the AWS parameter store
+    or on in the cdk.json file as a `context` value.
+    """
+    VALID_LOCATIONS = ["local", "ssm"]
+    secrets_environment_var = environ.get("SECRETS")
+    if secrets_environment_var is None:
+        location = "local"  # default secrets location
+    elif secrets_environment_var in VALID_LOCATIONS:
+        location = secrets_environment_var
+    else:
+        valid_locations_str = ",".join(VALID_LOCATIONS)
+        raise SystemExit(
+            f"Must set environment variable `SECRETS` to one of {valid_locations_str}"
+        )
+
+    return location
+
+
+def get_ssm_secrets(param_store_secret_refs: dict) -> dict:
+    """
+    Retrieve secrets from the AWS SSM parameter store.
+    """
+    ssm = boto3.client("ssm")
+    secrets = {}
+    for key, value in param_store_secret_refs.items():
+        secret_name = key
+        try:
+            response = ssm.get_parameter(Name=value, WithDecryption=True)
+            secret_value = response["Parameter"]["Value"]
+            secrets[secret_name] = secret_value
+        except ClientError as e:
+            raise e
+
+    return secrets
+
+
+def get_secrets(app: cdk.App) -> dict:
+    """
+    Secrets can be stored in the following locations:
+      1. Directly in the cdk.json file in a `secrets` context
+      2. In the AWS SSM parameter store
+    Retrieve secrets from one of those locations.
+    """
+    secrets_location = get_secrets_location()
+    if secrets_location == "local":
+        secrets = app.node.try_get_context("secrets")
+    elif secrets_location == "ssm":
+        param_store_secret_refs = app.node.try_get_context("secrets")
+        secrets = get_ssm_secrets(param_store_secret_refs)
+
+    return secrets

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 aws-cdk-lib==2.139.0
 constructs>=10.0.0,<11.0.0
-jproperties>=2.1.1
+boto3>=1.34.1


### PR DESCRIPTION
The AWS CDK uses cdk.json to provide context to the CDK. Instead of reinventing the wheel we piggy back on that feature and use the cdk.json to get environment parameters and secrets for the openchallenges application

