### PR TITLE
[IT-3878] Enable HTTPS for open challenges

### DIFF
--- a/app.py
+++ b/app.py
@@ -348,6 +348,6 @@ apex_service_stack = LoadBalancedHttpsServiceStack(
 )
 apex_service_stack.add_dependency(oc_app_stack)
 apex_service_stack.add_dependency(api_docs_stack)
-
+apex_service_stack.add_dependency(load_balancer_stack)
 
 app.synth()

--- a/app.py
+++ b/app.py
@@ -275,9 +275,9 @@ oc_app_props = ServiceProps(
     1024,
     "ghcr.io/sage-bionetworks/openchallenges-app:edge",
     {
-        "API_DOCS_URL": "http://opench-applo-0n9hz4aps1ms-1653316793.us-east-1.elb.amazonaws.com/api-docs",
+        "API_DOCS_URL": "https://newinfra.openchallenges.io/api-docs",
         "APP_VERSION": "1.0.0-alpha",
-        "CSR_API_URL": "http://opench-applo-0n9hz4aps1ms-1653316793.us-east-1.elb.amazonaws.com/api/v1",
+        "CSR_API_URL": "https://newinfra.openchallenges.io/api/v1",
         "DATA_UPDATED_ON": "2023-09-26",
         "ENVIRONMENT": "production",
         "GOOGLE_TAG_MANAGER_ID": "",

--- a/app.py
+++ b/app.py
@@ -4,7 +4,6 @@ from openchallenges.bucket_stack import BucketStack
 from openchallenges.network_stack import NetworkStack
 from openchallenges.ecs_stack import EcsStack
 from openchallenges.service_stack import ServiceStack
-from openchallenges.service_stack import LoadBalancedHttpServiceStack
 from openchallenges.service_stack import LoadBalancedHttpsServiceStack
 from openchallenges.load_balancer_stack import LoadBalancerStack
 from openchallenges.service_props import ServiceProps
@@ -309,15 +308,12 @@ api_docs_props = ServiceProps(
     "ghcr.io/sage-bionetworks/openchallenges-api-docs:edge",
     {"PORT": "8010"},
 )
-api_docs_stack = LoadBalancedHttpServiceStack(
+api_docs_stack = ServiceStack(
     app,
     "openchallenges-api-docs",
     network_stack.vpc,
     ecs_stack.cluster,
     api_docs_props,
-    load_balancer_stack.alb,
-    8010,
-    health_check_interval=5,
 )
 
 apex_service_props = ServiceProps(

--- a/app.py
+++ b/app.py
@@ -4,7 +4,8 @@ from openchallenges.bucket_stack import BucketStack
 from openchallenges.network_stack import NetworkStack
 from openchallenges.ecs_stack import EcsStack
 from openchallenges.service_stack import ServiceStack
-from openchallenges.service_stack import LoadBalancedServiceStack
+from openchallenges.service_stack import LoadBalancedHttpServiceStack
+from openchallenges.service_stack import LoadBalancedHttpsServiceStack
 from openchallenges.load_balancer_stack import LoadBalancerStack
 from openchallenges.service_props import ServiceProps
 import openchallenges.utils as utils
@@ -308,7 +309,7 @@ api_docs_props = ServiceProps(
     "ghcr.io/sage-bionetworks/openchallenges-api-docs:edge",
     {"PORT": "8010"},
 )
-api_docs_stack = LoadBalancedServiceStack(
+api_docs_stack = LoadBalancedHttpServiceStack(
     app,
     "openchallenges-api-docs",
     network_stack.vpc,
@@ -338,7 +339,7 @@ apex_service_props = ServiceProps(
     },
 )
 
-apex_service_stack = LoadBalancedServiceStack(
+apex_service_stack = LoadBalancedHttpsServiceStack(
     app,
     "openchallenges-apex",
     network_stack.vpc,
@@ -347,7 +348,7 @@ apex_service_stack = LoadBalancedServiceStack(
     load_balancer_stack.alb,
     80,
     "/health",
-    5,
+    health_check_interval=5,
 )
 apex_service_stack.add_dependency(oc_app_stack)
 apex_service_stack.add_dependency(api_docs_stack)

--- a/openchallenges/service_stack.py
+++ b/openchallenges/service_stack.py
@@ -119,7 +119,7 @@ class ServiceStack(cdk.Stack):
 
 class LoadBalancedHttpServiceStack(ServiceStack):
     """
-    A special stack to create a ECS service fronted by a load balancer. This allows us to split up
+    A special stack to create an ECS service fronted by a load balancer. This allows us to split up
     the ECS services and the load balancer into separate stacks.  It makes maintaining the stacks
     easier.  Unfortunately, due to the way AWS works, setting up a load balancer and ECS service
     in different stacks may cause cyclic references.
@@ -144,13 +144,6 @@ class LoadBalancedHttpServiceStack(ServiceStack):
     ) -> None:
         super().__init__(scope, construct_id, vpc, cluster, props, **kwargs)
 
-        # -------------------
-        # ACM Certificate for HTTPS
-        # -------------------
-        self.cert = acm.Certificate.from_certificate_arn(
-            self, "Cert", certificate_arn=CERTIFICATE_ARN
-        )
-
         http_listener = elbv2.ApplicationListener(
             self,
             "HttpListener",
@@ -173,7 +166,7 @@ class LoadBalancedHttpServiceStack(ServiceStack):
 
 class LoadBalancedHttpsServiceStack(ServiceStack):
     """
-    A special stack to create a ECS service fronted by a load balancer. This allows us to split up
+    A special stack to create an ECS service fronted by a load balancer. This allows us to split up
     the ECS services and the load balancer into separate stacks.  It makes maintaining the stacks
     easier.  Unfortunately, due to the way AWS works, setting up a load balancer and ECS service
     in different stacks may cause cyclic references.
@@ -239,6 +232,7 @@ class LoadBalancedHttpsServiceStack(ServiceStack):
             open=True,
             protocol=elbv2.ApplicationProtocol.HTTP,
         )
+
         http_listener.add_action(
             "HttpRedirect",
             action=elbv2.ListenerAction.redirect(

--- a/openchallenges/service_stack.py
+++ b/openchallenges/service_stack.py
@@ -117,7 +117,7 @@ class ServiceStack(cdk.Stack):
             )
 
 
-class LoadBalancedServiceStack(ServiceStack):
+class LoadBalancedHttpServiceStack(ServiceStack):
     """
     A special stack to create a ECS service fronted by a load balancer. This allows us to split up
     the ECS services and the load balancer into separate stacks.  It makes maintaining the stacks
@@ -161,7 +161,61 @@ class LoadBalancedServiceStack(ServiceStack):
         )
 
         http_listener.add_targets(
-            "Target",
+            "HttpTarget",
+            port=props.container_port,
+            protocol=elbv2.ApplicationProtocol.HTTP,
+            targets=[self.service],
+            health_check=elbv2.HealthCheck(
+                path=health_check_path, interval=duration.minutes(health_check_interval)
+            ),
+        )
+
+
+class LoadBalancedHttpsServiceStack(ServiceStack):
+    """
+    A special stack to create a ECS service fronted by a load balancer. This allows us to split up
+    the ECS services and the load balancer into separate stacks.  It makes maintaining the stacks
+    easier.  Unfortunately, due to the way AWS works, setting up a load balancer and ECS service
+    in different stacks may cause cyclic references.
+    https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_ecs/README.html#using-a-load-balancer-from-a-different-stack
+
+    To work around this problem we use the "Split at listener" option from
+    https://github.com/aws-samples/aws-cdk-examples
+    """
+
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        vpc: ec2.Vpc,
+        cluster: ecs.Cluster,
+        props: ServiceProps,
+        load_balancer: elbv2.ApplicationLoadBalancer,
+        listener_port: int,
+        health_check_path: str = "/",
+        health_check_interval: int = 1,  # max is 5
+        **kwargs,
+    ) -> None:
+        super().__init__(scope, construct_id, vpc, cluster, props, **kwargs)
+
+        # -------------------
+        # ACM Certificate for HTTPS
+        # -------------------
+        self.cert = acm.Certificate.from_certificate_arn(
+            self, "Cert", certificate_arn=CERTIFICATE_ARN
+        )
+
+        http_listener = elbv2.ApplicationListener(
+            self,
+            "HttpListener",
+            load_balancer=load_balancer,
+            port=listener_port,
+            open=True,
+            protocol=elbv2.ApplicationProtocol.HTTP,
+        )
+
+        http_listener.add_targets(
+            "HttpTarget",
             port=props.container_port,
             protocol=elbv2.ApplicationProtocol.HTTP,
             targets=[self.service],


### PR DESCRIPTION
Setup https://newinfra.openchallenges.io endpoint.  This DNS name is only temporary
to get OC working in a dev environment.

* Split LoadBalancedServiceStack class to two separate classes,
   LoadBalancedHttpServiceStack and LoadBalancedHttpsServiceStack
* Do not expose api docs on http port, make it available in https port
