### PR TITLE
[IT-3891] Multiple deployments and fix thumbor bucket access

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: us-east-1
-          role-to-assume: 'arn:aws:iam::804034162148:role/sagebase-github-oidc-openchallenges-deploy'
+          role-to-assume: 'arn:aws:iam::221082174873:role/sagebase-github-oidc-openchallenges-deploy'
           role-session-name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
           role-duration-seconds: 1200
       - name: CDK deploy

--- a/app.py
+++ b/app.py
@@ -32,6 +32,7 @@ network_stack = NetworkStack(app, f"{stack_name_prefix}-network", vpc_cidr)
 ecs_stack = EcsStack(
     app, f"{stack_name_prefix}-ecs", network_stack.vpc, fully_qualified_domain_name
 )
+ecs_stack.add_dependency(network_stack)
 
 mariadb_props = ServiceProps(
     "openchallenges-mariadb",

--- a/app.py
+++ b/app.py
@@ -91,8 +91,6 @@ thumbor_props = ServiceProps(
         "LOADER": "thumbor_aws.loader",
         "AWS_LOADER_REGION_NAME": "us-east-1",
         "AWS_LOADER_BUCKET_NAME": bucket_stack.openchallenges_img_bucket.bucket_name,
-        "AWS_LOADER_S3_ACCESS_KEY_ID": secrets["AWS_LOADER_S3_ACCESS_KEY_ID"],
-        "AWS_LOADER_S3_SECRET_ACCESS_KEY": secrets["AWS_LOADER_S3_SECRET_ACCESS_KEY"],
         "AWS_LOADER_S3_ENDPOINT_URL": "http://s3.us-east-1.amazonaws.com",
         "AWS_LOADER_ROOT_PATH": "img",
         "STORAGE": "thumbor.storages.file_storage",
@@ -117,6 +115,7 @@ thumbor_stack = ServiceStack(
     ecs_stack.cluster,
     thumbor_props,
 )
+thumbor_stack.add_dependency(bucket_stack)
 
 config_server_props = ServiceProps(
     "openchallenges-config-server",

--- a/cdk.json
+++ b/cdk.json
@@ -65,8 +65,17 @@
     "@aws-cdk/aws-eks:nodegroupNameAttribute": true,
     "dev": {
         "VPC_CIDR": "10.255.92.0/24",
-        "DNS_NAMESPACE": "openchallenges.io",
-        "DNS_SUBDOMAIN": "newinfra",
+        "FQDN": "dev.openchallenges.io",
+        "CERTIFICATE_ARN": "arn:aws:acm:us-east-1:804034162148:certificate/76ed5a71-4aa8-4cc1-9db6-aa7a322ec077"
+      },
+    "stage": {
+        "VPC_CIDR": "10.255.92.0/24",
+        "FQDN": "stage.openchallenges.io",
+        "CERTIFICATE_ARN": "arn:aws:acm:us-east-1:804034162148:certificate/76ed5a71-4aa8-4cc1-9db6-aa7a322ec077"
+      },
+    "prod": {
+        "VPC_CIDR": "10.255.92.0/24",
+        "FQDN": "prod.openchallenges.io",
         "CERTIFICATE_ARN": "arn:aws:acm:us-east-1:804034162148:certificate/76ed5a71-4aa8-4cc1-9db6-aa7a322ec077"
       },
     "secrets": {

--- a/cdk.json
+++ b/cdk.json
@@ -71,12 +71,12 @@
     "stage": {
         "VPC_CIDR": "10.255.93.0/24",
         "FQDN": "stage.openchallenges.io",
-        "CERTIFICATE_ARN": "arn:aws:acm:us-east-1:766808016710:certificate/4e9c7a02-bd99-486a-a2ad-270a88676ae1"
+        "CERTIFICATE_ARN": "arn:aws:acm:us-east-1:528757786185:certificate/d679947f-90ed-4a4b-9d49-e728af5ae546"
       },
     "prod": {
         "VPC_CIDR": "10.255.94.0/24",
         "FQDN": "prod.openchallenges.io",
-        "CERTIFICATE_ARN": "arn:aws:acm:us-east-1:766808016710:certificate/4e9c7a02-bd99-486a-a2ad-270a88676ae1"
+        "CERTIFICATE_ARN": "arn:aws:acm:us-east-1:528757786185:certificate/d679947f-90ed-4a4b-9d49-e728af5ae546"
       },
     "secrets": {
         "MARIADB_PASSWORD": "/openchallenges/MARIADB_PASSWORD",

--- a/cdk.json
+++ b/cdk.json
@@ -66,17 +66,17 @@
     "dev": {
         "VPC_CIDR": "10.255.92.0/24",
         "FQDN": "dev.openchallenges.io",
-        "CERTIFICATE_ARN": "arn:aws:acm:us-east-1:804034162148:certificate/76ed5a71-4aa8-4cc1-9db6-aa7a322ec077"
+        "CERTIFICATE_ARN": "arn:aws:acm:us-east-1:221082174873:certificate/4bd9e6ac-0951-485e-a132-e842aaf2ec58"
       },
     "stage": {
-        "VPC_CIDR": "10.255.92.0/24",
+        "VPC_CIDR": "10.255.93.0/24",
         "FQDN": "stage.openchallenges.io",
-        "CERTIFICATE_ARN": "arn:aws:acm:us-east-1:804034162148:certificate/76ed5a71-4aa8-4cc1-9db6-aa7a322ec077"
+        "CERTIFICATE_ARN": "arn:aws:acm:us-east-1:766808016710:certificate/4e9c7a02-bd99-486a-a2ad-270a88676ae1"
       },
     "prod": {
-        "VPC_CIDR": "10.255.92.0/24",
+        "VPC_CIDR": "10.255.94.0/24",
         "FQDN": "prod.openchallenges.io",
-        "CERTIFICATE_ARN": "arn:aws:acm:us-east-1:804034162148:certificate/76ed5a71-4aa8-4cc1-9db6-aa7a322ec077"
+        "CERTIFICATE_ARN": "arn:aws:acm:us-east-1:766808016710:certificate/4e9c7a02-bd99-486a-a2ad-270a88676ae1"
       },
     "secrets": {
         "MARIADB_PASSWORD": "/openchallenges/MARIADB_PASSWORD",

--- a/openchallenges/bucket_stack.py
+++ b/openchallenges/bucket_stack.py
@@ -1,6 +1,6 @@
 import aws_cdk as cdk
 
-from aws_cdk import aws_s3 as s3, aws_iam as iam
+from aws_cdk import aws_s3 as s3
 
 from constructs import Construct
 
@@ -32,31 +32,4 @@ class BucketStack(cdk.Stack):
             self,
             "ImageBucketName",
             value=self.openchallenges_img_bucket.bucket_name,
-        )
-
-        # -------------------
-        # IAM user with access to the openchallenges bucket
-        # -------------------
-        self.s3_user = iam.User(self, "ThumborUser", user_name="openchallenges-thumbor")
-        # self.access_key = iam.AccessKey(self, "AccessKey", user=self.s3_user)
-        # secret = ssm.Secret(
-        #     self,
-        #     "SecretAccessKey",
-        #     secret_string_value=self.access_key.secret_access_key,
-        # )
-        # cdk.CfnOutput(self, "AccessKeyId", value=self.access_key.access_key_id)
-
-        self.s3_user.add_to_policy(
-            iam.PolicyStatement(
-                effect=iam.Effect.ALLOW,
-                resources=[self.openchallenges_img_bucket.bucket_arn],
-                actions=["s3:ListBucket", "s3:GetObject*"],
-            )
-        )
-        self.s3_user.add_to_policy(
-            iam.PolicyStatement(
-                effect=iam.Effect.ALLOW,
-                resources=[f"{self.openchallenges_img_bucket.bucket_arn}/*"],
-                actions=["s3:*Object"],
-            )
         )

--- a/openchallenges/load_balancer_stack.py
+++ b/openchallenges/load_balancer_stack.py
@@ -7,11 +7,6 @@ from aws_cdk import (
 
 from constructs import Construct
 
-ALB_HTTP_LISTENER_PORT = 80
-ALB_HTTPS_LISTENER_PORT = 443
-# manually created cert
-CERTIFICATE_ARN = "arn:aws:acm:us-east-1:804034162148:certificate/76ed5a71-4aa8-4cc1-9db6-aa7a322ec077"
-
 
 class LoadBalancerStack(cdk.Stack):
     """

--- a/openchallenges/service_stack.py
+++ b/openchallenges/service_stack.py
@@ -8,6 +8,7 @@ from aws_cdk import (
     Size as size,
     aws_elasticloadbalancingv2 as elbv2,
     aws_certificatemanager as acm,
+    aws_iam as iam,
 )
 
 from constructs import Construct
@@ -33,12 +34,39 @@ class ServiceStack(cdk.Stack):
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
+        # allow containers default task access and s3 bucket access
+        task_role = iam.Role(
+            self,
+            "TaskRole",
+            assumed_by=iam.ServicePrincipal("ecs-tasks.amazonaws.com"),
+            managed_policies=[
+                iam.ManagedPolicy.from_aws_managed_policy_name("AmazonS3FullAccess"),
+            ],
+        )
+        task_role.add_to_policy(
+            iam.PolicyStatement(
+                actions=[
+                    "logs:CreateLogStream",
+                    "logs:DescribeLogGroups",
+                    "logs:DescribeLogStreams",
+                    "logs:PutLogEvents",
+                    "ssmmessages:CreateControlChannel",
+                    "ssmmessages:CreateDataChannel",
+                    "ssmmessages:OpenControlChannel",
+                    "ssmmessages:OpenDataChannel",
+                ],
+                resources=["*"],
+                effect=iam.Effect.ALLOW,
+            )
+        )
+
         # ECS task with fargate
         self.task_definition = ecs.FargateTaskDefinition(
             self,
             "TaskDef",
             cpu=1024,
             memory_limit_mib=4096,
+            task_role=task_role,
         )
 
         image = ecs.ContainerImage.from_registry(props.container_location)

--- a/openchallenges/service_stack.py
+++ b/openchallenges/service_stack.py
@@ -135,7 +135,6 @@ class LoadBalancedServiceStack(ServiceStack):
         cluster: ecs.Cluster,
         props: ServiceProps,
         load_balancer: elbv2.ApplicationLoadBalancer,
-        listener_port: int,
         certificate_arn: str,
         health_check_path: str = "/",
         health_check_interval: int = 1,  # max is 5

--- a/openchallenges/utils.py
+++ b/openchallenges/utils.py
@@ -8,10 +8,10 @@ from os import environ
 def get_environment() -> str:
     """
     The `ENV` environment variable's value represents the deployment
-    environment (dev, prod, etc..).  This method gets the `ENV`
+    environment (dev, stage, prod, etc..).  This method gets the `ENV`
     environment variable's value
     """
-    VALID_ENVS = ["dev", "prod"]
+    VALID_ENVS = ["dev", "stage", "prod"]
 
     env_environment_var = environ.get("ENV")
     if env_environment_var is None:


### PR DESCRIPTION
We plan to deploy stage and prod to the same AWS account. However AWS cloudformation requires stack names to be unique therefore we need to add a prefix to each stack name. This PR proposes to add the environment name to each stack name (i.e. openchallenges-dev, openchallenges-stage, openchallenges-prod) so that we can deploy multiple openchallenge apps to a single account using the AWS CDK.

```
➜  openchallenges git:(oc-prefix) ENV=dev cdk synth
Successfully synthesized to /Users/zaro0508/work-sage/openchallenges/cdk.out
Supply a stack id (openchallenges-dev-buckets, openchallenges-dev-network, openchallenges-dev-ecs,
openchallenges-dev-mariadb, openchallenges-dev-elasticsearch, openchallenges-dev-thumbor,
openchallenges-dev-config-server, openchallenges-dev-service-registry, openchallenges-dev-zipkin,
openchallenges-dev-image-service, openchallenges-dev-challenge-service,
openchallenges-dev-organization-service, openchallenges-dev-api-gateway, openchallenges-dev-app,
openchallenges-dev-load-balancer, openchallenges-dev-api-docs, openchallenges-dev-apex)

```

```
➜  openchallenges git:(oc-prefix) ENV=prod cdk synth
Successfully synthesized to /Users/zaro0508/work-sage/openchallenges/cdk.out
Supply a stack id (openchallenges-prod-buckets, openchallenges-prod-network, openchallenges-prod-ecs,
openchallenges-prod-mariadb, openchallenges-prod-elasticsearch, openchallenges-prod-thumbor,
openchallenges-prod-config-server, openchallenges-prod-service-registry, openchallenges-prod-zipkin,
openchallenges-prod-image-service, openchallenges-prod-challenge-service,
openchallenges-prod-organization-service, openchallenges-prod-api-gateway, openchallenges-prod-app,
openchallenges-prod-load-balancer, openchallenges-prod-api-docs, openchallenges-prod-apex) to display its template.
```

We are setting a specific user_name which thumbor uses to access the S3 bucket.  The problem in AWS land is that user names need to be unique in an AWS account.  When we deploy multiple environments (sage and prod) to the same AWS account, the 1st deployment will create the user, however the 2nd deployment will fail because it cannot create a user with the same name. To fix this we update the infra to give all containers access to the OC bucket so that we don't need to provide thumbor with any user access keys.
