### PR TITLE
Remove shared certificate

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -71,12 +71,12 @@
     "stage": {
         "VPC_CIDR": "10.255.93.0/24",
         "FQDN": "stage.openchallenges.io",
-        "CERTIFICATE_ARN": "arn:aws:acm:us-east-1:528757786185:certificate/a6d71846-25c6-42f1-9fe0-d65c8a5c4b79"
+        "CERTIFICATE_ARN": "arn:aws:acm:us-east-1:528757786185:certificate/7018402f-7774-4890-84d8-43b8748eba53"
       },
     "prod": {
         "VPC_CIDR": "10.255.94.0/24",
         "FQDN": "prod.openchallenges.io",
-        "CERTIFICATE_ARN": "arn:aws:acm:us-east-1:528757786185:certificate/a6d71846-25c6-42f1-9fe0-d65c8a5c4b79"
+        "CERTIFICATE_ARN": "arn:aws:acm:us-east-1:528757786185:certificate/6d591cce-5097-42ef-9d3d-e746f01e33a7"
       },
     "secrets": {
         "MARIADB_PASSWORD": "/openchallenges/MARIADB_PASSWORD",


### PR DESCRIPTION
Stage and Prod are sharing an ACM certificate.  The best practice is to create separate certificates for the two environments to reduce security risk.

