### PR TITLE
[IT-3918] Fix the image URLs returned by the image service

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ OpenChallenges application.
 * Add the Certificate ARN to the cdk.json
 * Update references to the OC docker images in [app.py](app.py)
   (i.e. `ghcr.io/sage-bionetworks/openchallenges-xxx:<tag>`)
-* (Optional) Update the ServiceProps objects in [app.py](app.py) with parameters specific to
+* (Optional) Update the `ServiceProps` objects in [app.py](app.py) with parameters specific to
   each container.
 
 ## Login with the AWS CLI

--- a/app.py
+++ b/app.py
@@ -180,7 +180,7 @@ image_service_props = ServiceProps(
         "SERVER_PORT": "8086",
         "SPRING_CLOUD_CONFIG_URI": "http://openchallenges-config-server:8090",
         "SERVICE_REGISTRY_URL": "http://openchallenges-service-registry:8081/eureka",
-        "OPENCHALLENGES_IMAGE_SERVICE_THUMBOR_HOST": "https://dev.openchallenges.io/img/",
+        "OPENCHALLENGES_IMAGE_SERVICE_THUMBOR_HOST": "https://{fully_qualified_domain_name}/img/",
         "OPENCHALLENGES_IMAGE_SERVICE_THUMBOR_SECURITY_KEY": secrets["SECURITY_KEY"],
         "OPENCHALLENGES_IMAGE_SERVICE_IS_DEPLOYED_ON_AWS": "true",
     },

--- a/app.py
+++ b/app.py
@@ -180,6 +180,8 @@ image_service_props = ServiceProps(
         "SERVER_PORT": "8086",
         "SPRING_CLOUD_CONFIG_URI": "http://openchallenges-config-server:8090",
         "SERVICE_REGISTRY_URL": "http://openchallenges-service-registry:8081/eureka",
+        "OPENCHALLENGES_IMAGE_SERVICE_THUMBOR_HOST": "https://dev.openchallenges.io/img/",
+        "OPENCHALLENGES_IMAGE_SERVICE_THUMBOR_SECURITY_KEY": secrets["SECURITY_KEY"],
         "OPENCHALLENGES_IMAGE_SERVICE_IS_DEPLOYED_ON_AWS": "true",
     },
 )

--- a/app.py
+++ b/app.py
@@ -180,7 +180,7 @@ image_service_props = ServiceProps(
         "SERVER_PORT": "8086",
         "SPRING_CLOUD_CONFIG_URI": "http://openchallenges-config-server:8090",
         "SERVICE_REGISTRY_URL": "http://openchallenges-service-registry:8081/eureka",
-        "OPENCHALLENGES_IMAGE_SERVICE_THUMBOR_HOST": "https://{fully_qualified_domain_name}/img/",
+        "OPENCHALLENGES_IMAGE_SERVICE_THUMBOR_HOST": f"https://{fully_qualified_domain_name}/img/",
         "OPENCHALLENGES_IMAGE_SERVICE_THUMBOR_SECURITY_KEY": secrets["SECURITY_KEY"],
         "OPENCHALLENGES_IMAGE_SERVICE_IS_DEPLOYED_ON_AWS": "true",
     },


### PR DESCRIPTION
Fixes https://sagebionetworks.jira.com/browse/IT-3918

## Changelog

- Update the environment variables of the image service to generate valid URLs to images served by Thumbor

## Notes

Thumbor's SVG to PNG conversion is broken, which likely occurred when we updated recently updated the Docker image so that it works with AWS managed policy.

## Preview

`https://dev.openchallenges.io`:

![image](https://github.com/user-attachments/assets/136b892d-b8c8-4f8e-a600-7a7058e1744f)

## Update

The conversion of SVG images to PNG images has been fixed by using a non-slim version of Thumbor.
