### PR TITLE
Increase GH workflow timeout

### DIFF
--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -20,7 +20,7 @@ on:
         type: string
       role-duration-seconds:
         type: number
-        default: 1200
+        default: 3600
       environment:
         required: true
         type: string


### PR DESCRIPTION
A change[1] was made to update all containers at the same time which takes longer to deploy. the increased time causes a an assume role timeout therefore we need to increase that timeout.

[1] https://github.com/Sage-Bionetworks-IT/openchallenges/pull/54
