### PR TITLE
chore: Enable the concurrent deployment of containers (ARCH-318)

### DIFF
--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -52,7 +52,7 @@ jobs:
           role-session-name: ${{ inputs.role-session-name }}
           role-duration-seconds: ${{ inputs.role-duration-seconds }}
       - name: CDK deploy
-        run: cdk deploy --all --require-approval never
+        run: cdk deploy --all --concurrency 5 --require-approval never
         env:
           ENV: ${{ inputs.environment }}
           SECRETS: ${{ inputs.secrets-location }}


### PR DESCRIPTION
Closes https://sagebionetworks.jira.com/browse/ARCH-318

The current deployment time takes about 1h15. This led to deployment timeouts. One way we handled them is to increase the max timeout.

This PR enables the concurrent deployment of containers to accelerate the overall deployment time. Based on local experiment:

- concurrency 1 => 73 minutes
- concurrency 3 => 43 minutes
- concurrency 10 => 37 minutes

This PR sets the concurrency value to 5 because of the diminishing return observed.