### PR TITLE
Refactor mounting volumes

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ from openchallenges.ecs_stack import EcsStack
 from openchallenges.service_stack import ServiceStack
 from openchallenges.service_stack import LoadBalancedServiceStack
 from openchallenges.load_balancer_stack import LoadBalancerStack
-from openchallenges.service_props import ServiceProps
+from openchallenges.service_props import ServiceProps, ContainerVolume
 import openchallenges.utils as utils
 
 app = cdk.App()
@@ -45,6 +45,12 @@ mariadb_props = ServiceProps(
         "MARIADB_PASSWORD": secrets["MARIADB_PASSWORD"],
         "MARIADB_ROOT_PASSWORD": secrets["MARIADB_ROOT_PASSWORD"],
     },
+    container_volumes=[
+        ContainerVolume(
+            path="/data/db",
+            size=30,
+        )
+    ],
 )
 
 mariadb_stack = ServiceStack(

--- a/openchallenges/service_props.py
+++ b/openchallenges/service_props.py
@@ -1,4 +1,23 @@
+from dataclasses import dataclass
+from typing import List
+
 CONTAINER_LOCATION_PATH_ID = "path://"
+
+
+@dataclass
+class ContainerVolume:
+    """
+    Holds onto configuration for a volume used in the container.
+
+    Attributes:
+      path: The path on the container to mount the host volume at.
+      size: The size of the volume in GiB.
+      read_only: Container has read-only access to the volume, set to `false` for write access.
+    """
+
+    path: str
+    size: int = 15
+    read_only: bool = False
 
 
 class ServiceProps:
@@ -13,6 +32,7 @@ class ServiceProps:
       supports docker registry references (i.e. ghcr.io/sage-bionetworks/openchallenges-thumbor:latest)
     container_env_vars: a json dictionary of environment variables to pass into the container
       i.e. {"EnvA": "EnvValueA", "EnvB": "EnvValueB"}
+    container_volumes: List of `ContainerVolume` resources to mount into the container
     """
 
     def __init__(
@@ -22,6 +42,7 @@ class ServiceProps:
         container_memory: int,
         container_location: str,
         container_env_vars: dict,
+        container_volumes: List[ContainerVolume] = None,
     ) -> None:
         self.container_name = container_name
         self.container_port = container_port
@@ -32,3 +53,7 @@ class ServiceProps:
             )
         self.container_location = container_location
         self.container_env_vars = container_env_vars
+        if container_volumes is None:
+            self.container_volumes = []
+        else:
+            self.container_volumes = container_volumes


### PR DESCRIPTION
The current implementation to mount volumes was very specific to one container.  We are replacing it with an implementation that is much more generic to make it easy to mount volumes in other containers.

