### PR TITLE
[IT-3951] Fix guardduty container

### DIFF
--- a/openchallenges/service_stack.py
+++ b/openchallenges/service_stack.py
@@ -63,6 +63,50 @@ class ServiceStack(cdk.Stack):
             )
         )
 
+        # default ECS execution policy plus Guardduty access
+        execution_role = iam.Role(
+            self,
+            "ExecutionRole",
+            assumed_by=iam.ServicePrincipal("ecs-tasks.amazonaws.com"),
+            managed_policies=[
+                iam.ManagedPolicy.from_aws_managed_policy_name(
+                    "service-role/AmazonECSTaskExecutionRolePolicy"
+                ),
+            ],
+        )
+        execution_role.add_to_policy(
+            iam.PolicyStatement(
+                actions=[
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents",
+                ],
+                resources=["*"],
+                effect=iam.Effect.ALLOW,
+            )
+        )
+
+        # default ECS execution policy plus Guardduty access
+        execution_role = iam.Role(
+            self,
+            "ExecutionRole",
+            assumed_by=iam.ServicePrincipal("ecs-tasks.amazonaws.com"),
+            managed_policies=[
+                iam.ManagedPolicy.from_aws_managed_policy_name(
+                    "service-role/AmazonECSTaskExecutionRolePolicy"
+                ),
+            ],
+        )
+        execution_role.add_to_policy(
+            iam.PolicyStatement(
+                actions=[
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents",
+                ],
+                resources=["*"],
+                effect=iam.Effect.ALLOW,
+            )
+        )
+
         # ECS task with fargate
         self.task_definition = ecs.FargateTaskDefinition(
             self,
@@ -70,6 +114,7 @@ class ServiceStack(cdk.Stack):
             cpu=1024,
             memory_limit_mib=4096,
             task_role=task_role,
+            execution_role=execution_role,
         )
 
         image = ecs.ContainerImage.from_registry(props.container_location)

--- a/openchallenges/service_stack.py
+++ b/openchallenges/service_stack.py
@@ -41,6 +41,9 @@ class ServiceStack(cdk.Stack):
             assumed_by=iam.ServicePrincipal("ecs-tasks.amazonaws.com"),
             managed_policies=[
                 iam.ManagedPolicy.from_aws_managed_policy_name("AmazonS3FullAccess"),
+                iam.ManagedPolicy.from_aws_managed_policy_name(
+                    "service-role/service-role/AmazonECSTaskExecutionRolePolicy"
+                ),
             ],
         )
         task_role.add_to_policy(

--- a/openchallenges/service_stack.py
+++ b/openchallenges/service_stack.py
@@ -41,9 +41,6 @@ class ServiceStack(cdk.Stack):
             assumed_by=iam.ServicePrincipal("ecs-tasks.amazonaws.com"),
             managed_policies=[
                 iam.ManagedPolicy.from_aws_managed_policy_name("AmazonS3FullAccess"),
-                iam.ManagedPolicy.from_aws_managed_policy_name(
-                    "service-role/service-role/AmazonECSTaskExecutionRolePolicy"
-                ),
             ],
         )
         task_role.add_to_policy(
@@ -57,28 +54,6 @@ class ServiceStack(cdk.Stack):
                     "ssmmessages:CreateDataChannel",
                     "ssmmessages:OpenControlChannel",
                     "ssmmessages:OpenDataChannel",
-                ],
-                resources=["*"],
-                effect=iam.Effect.ALLOW,
-            )
-        )
-
-        # default ECS execution policy plus Guardduty access
-        execution_role = iam.Role(
-            self,
-            "ExecutionRole",
-            assumed_by=iam.ServicePrincipal("ecs-tasks.amazonaws.com"),
-            managed_policies=[
-                iam.ManagedPolicy.from_aws_managed_policy_name(
-                    "service-role/AmazonECSTaskExecutionRolePolicy"
-                ),
-            ],
-        )
-        execution_role.add_to_policy(
-            iam.PolicyStatement(
-                actions=[
-                    "logs:CreateLogStream",
-                    "logs:PutLogEvents",
                 ],
                 resources=["*"],
                 effect=iam.Effect.ALLOW,


### PR DESCRIPTION
We enable guardduty security monitoring for ECS in every account.
For that to work we need to give Fragate tasks access to do ECS stuff
with the service-role/AmazonECSTaskExecutionRolePolicy[1].

[1] https://docs.aws.amazon.com/guardduty/latest/ug/prereq-runtime-monitoring-ecs-support.html#before-enable-runtime-monitoring-ecs
