### PR TITLE
Add Docker in Docker to the dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,14 +1,6 @@
 {
   "name": "AWS CDK & Python Development Environment",
   "image": "mcr.microsoft.com/devcontainers/base:ubuntu-22.04",
-  "containerEnv": {
-    "ENV": "${localEnv:ENV}",
-    "SECRETS": "${localEnv:SECRETS}",
-    "AWS_ACCESS_KEY_ID": "${localEnv:AWS_ACCESS_KEY_ID}",
-    "AWS_SECRET_ACCESS_KEY": "${localEnv:AWS_SECRET_ACCESS_KEY}",
-    "AWS_SESSION_TOKEN": "${localEnv:AWS_SESSION_TOKEN}",
-    "AWS_REGION": "${localEnv:AWS_REGION}"
-  },
   "features": {
     "ghcr.io/devcontainers/features/node:1.5.0": {
       "version": "22.6.0"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,14 @@
 {
   "name": "AWS CDK & Python Development Environment",
   "image": "mcr.microsoft.com/devcontainers/base:ubuntu-22.04",
+  "containerEnv": {
+    "ENV": "${localEnv:ENV}",
+    "SECRETS": "${localEnv:SECRETS}",
+    "AWS_ACCESS_KEY_ID": "${localEnv:AWS_ACCESS_KEY_ID}",
+    "AWS_SECRET_ACCESS_KEY": "${localEnv:AWS_SECRET_ACCESS_KEY}",
+    "AWS_SESSION_TOKEN": "${localEnv:AWS_SESSION_TOKEN}",
+    "AWS_REGION": "${localEnv:AWS_REGION}"
+  },
   "features": {
     "ghcr.io/devcontainers/features/node:1.5.0": {
       "version": "22.6.0"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,11 @@
     "ghcr.io/devcontainers/features/python:1.6.3": {
       "version": "3.12.0"
     },
-    "ghcr.io/devcontainers/features/aws-cli:1": {}
+    "ghcr.io/devcontainers/features/aws-cli:1": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2.12.0": {
+      "version": "27.0.3",
+      "moby": false
+    }
   },
   "postCreateCommand": "./tools/setup.sh",
   "shutdownAction": "stopContainer"

--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ tools can be installed by running:
 ./tools/setup.sh
 ```
 
+When developing outside the dev container, the following tools must be installed
+manually.
+
+- [Docker](https://docs.docker.com/engine/install/) >= v27
+
 Development requires the activation of the Python virtual environment:
 
 ```


### PR DESCRIPTION
Docker is required for building AWS Lambda container images (#72)

## Preview

Inside the dev container

```console
$ docker --version
Docker version 27.0.3, build 7d4bcd8
```

EDIT: Now forwarding selected environment variables from the host to the container when it's started.