### PR TITLE
Increase role duration to 90 minutes

### DIFF
--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -20,7 +20,7 @@ on:
         type: string
       role-duration-seconds:
         type: number
-        default: 3600
+        default: 5400
       environment:
         required: true
         type: string


### PR DESCRIPTION
The deployment failed on dev with the current timeout (60 minutes).

Note that settings the concurrent to 5 enable to previously deploy the stack in about 37 minutes (just a couple of time points, not enough to generalize). Since then, the only change should be the addition of a lambda function.