### PR TITLE
Specify the git ref to checkout during deploy

### DIFF
--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.environment }}
       - name: Install AWS CLI
         run: sudo snap install aws-cli --classic
       - name: Install AWS CDK CLI


### PR DESCRIPTION
When triggering jobs with `workflow_run` the default git ref to fetch is the default branch, causing all deploys to use the `dev` branch. Override the default ref with the name of the environment in order to deploy from the corresponding branch.

https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run