### PR TITLE
Fix CI: cannot assume role

### DIFF
--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -24,7 +24,6 @@ on:
       environment:
         required: true
         type: string
-        default: "dev"
       secrets-location:
         type: string
         default: "local"
@@ -38,8 +37,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          ref: ${{ inputs.environment }}
       - name: Install AWS CLI
         run: sudo snap install aws-cli --classic
       - name: Install AWS CDK CLI

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -1,15 +1,14 @@
 name: deploy-prod
 
 on:
-  workflow_run:
-    workflows:
-      - check
-    types:
-      - completed
-    branches:
-      - prod
+  push:
+    branches: ['prod']
 
 jobs:
+  test:
+    uses: ./.github/workflows/test.yaml
+    with:
+      environment: prod
   aws-deploy:
     uses: "./.github/workflows/aws-deploy.yaml"
     with:

--- a/.github/workflows/deploy-stage.yaml
+++ b/.github/workflows/deploy-stage.yaml
@@ -1,15 +1,14 @@
 name: deploy-stage
 
 on:
-  workflow_run:
-    workflows:
-      - check
-    types:
-      - completed
-    branches:
-      - stage
+  push:
+    branches: ['stage']
 
 jobs:
+  test:
+    uses: ./.github/workflows/test.yaml
+    with:
+      environment: stage
   aws-deploy:
     uses: "./.github/workflows/aws-deploy.yaml"
     with:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,11 @@
+name: pr-check
+
+on:
+  pull_request:
+    branches: ['*']
+
+jobs:
+  test:
+    uses: ./.github/workflows/test.yaml
+    with:
+      environment: dev

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,11 +1,11 @@
-name: check
+name: test
 
 on:
-  pull_request:
-    branches: ['*']
-  push:
-    branches: ['*']
-
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
@@ -25,6 +25,9 @@ jobs:
         run: pip install -r requirements.txt -r requirements-dev.txt
       - name: Generate cloudformation
         uses: youyo/aws-cdk-github-actions@v2
+        env:
+          ENV: ${{ inputs.environment }}
+          secrets-location: "ssm"
         with:
           cdk_subcommand: 'synth'
           actions_comment: false


### PR DESCRIPTION
The deployment is failing with following message[1]

```
Error: Could not assume role with OIDC:
Not authorized to perform sts:AssumeRoleWithWebIdentity
```

Not sure why it's failing but the similar CI setup for agora-infra-v3[2] works so attempting to fix with a refactor to the same setup.   

This is also a fix for when triggering jobs with workflow_run the default git ref to fetch is the default branch[3], causing all deploys to use the dev branch. We want the workflow to checkout the branch that trigger the event.  The github community suggestion is to change workflow_run to workflow_call[4]

[1] https://github.com/Sage-Bionetworks-IT/openchallenges/actions/runs/13117959589/job/36596798361
[2] https://github.com/Sage-Bionetworks-IT/agora-infra-v3/actions
[3] https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run
[4] https://github.com/orgs/community/discussions/72097#discussioncomment-7376117

